### PR TITLE
Align I tetromino rotations to shared anchor

### DIFF
--- a/src/main/scala/tetris/core/Model.scala
+++ b/src/main/scala/tetris/core/Model.scala
@@ -16,10 +16,10 @@ case class Piece(position: Point, shape: Tetromino, rotation: Int) {
 // Enum for the 7 tetromino shapes, their colors, and rotation patterns
 enum Tetromino(val color: Color, val rotations: Vector[Vector[Point]]) {
   case I extends Tetromino(Color.Cyan, Vector(
-    Vector(Point(-1, 0), Point(0, 0), Point(1, 0), Point(2, 0)),
-    Vector(Point(1, -1), Point(1, 0), Point(1, 1), Point(1, 2)),
-    Vector(Point(-1, 1), Point(0, 1), Point(1, 1), Point(2, 1)),
-    Vector(Point(0, -1), Point(0, 0), Point(0, 1), Point(0, 2))
+    Vector(Point(-2, 0), Point(-1, 0), Point(0, 0), Point(1, 0)),
+    Vector(Point(0, -2), Point(0, -1), Point(0, 0), Point(0, 1)),
+    Vector(Point(-2, 0), Point(-1, 0), Point(0, 0), Point(1, 0)),
+    Vector(Point(0, -2), Point(0, -1), Point(0, 0), Point(0, 1))
   ))
   case O extends Tetromino(Color.Yellow, Vector(
     Vector(Point(0, 0), Point(1, 0), Point(0, 1), Point(1, 1)),

--- a/src/test/scala/tetris/core/GameStateSpec.scala
+++ b/src/test/scala/tetris/core/GameStateSpec.scala
@@ -28,6 +28,34 @@ class GameStateSpec extends AnyFunSuite with Matchers {
     field.set(state, grid)
   }
 
+  test("I piece rotates in place when adjacent to a stack") {
+    withTempHighScore() {
+      val state = new GameState(GameConfig())
+      val stackColor = Color.Gray
+      val occupiedRows = Set(3, 4, 6)
+      val gridWithStack = Vector.tabulate(GridHeight) { y =>
+        Vector.tabulate(GridWidth) { x =>
+          if (x == GridWidth - 1 && occupiedRows.contains(y)) Some(stackColor) else None
+        }
+      }
+
+      setGrid(state, gridWithStack)
+
+      val anchor = Point(GridWidth - 2, 5)
+      state.currentPiece = Piece(anchor, Tetromino.I, rotation = 0)
+
+      state.rotateClockwise()
+
+      state.currentPiece.position shouldEqual anchor
+      state.currentPiece.blocks.toSet shouldEqual Set(
+        Point(anchor.x, anchor.y - 2),
+        Point(anchor.x, anchor.y - 1),
+        Point(anchor.x, anchor.y),
+        Point(anchor.x, anchor.y + 1)
+      )
+    }
+  }
+
   test("update moves the active piece down by one row when unobstructed") {
     withTempHighScore() {
       val state = new GameState(GameConfig())


### PR DESCRIPTION
## Summary
- anchor the I piece rotations so horizontal and vertical states use a common origin
- add a regression test that verifies the I piece can rotate beside an occupied stack

## Testing
- /tmp/sbt test

------
https://chatgpt.com/codex/tasks/task_e_68cd22e50ca08325a6a22b899e65c01e